### PR TITLE
Add support for the `skip-prune` option

### DIFF
--- a/docs/oapi_codegen.md
+++ b/docs/oapi_codegen.md
@@ -7,7 +7,7 @@
 ## oapi_codegen_go
 
 <pre>
-oapi_codegen_go(<a href="#oapi_codegen_go-name">name</a>, <a href="#oapi_codegen_go-spec">spec</a>, <a href="#oapi_codegen_go-importpath">importpath</a>, <a href="#oapi_codegen_go-visibility">visibility</a>, <a href="#oapi_codegen_go-kwargs">kwargs</a>)
+oapi_codegen_go(<a href="#oapi_codegen_go-name">name</a>, <a href="#oapi_codegen_go-spec">spec</a>, <a href="#oapi_codegen_go-importpath">importpath</a>, <a href="#oapi_codegen_go-visibility">visibility</a>, <a href="#oapi_codegen_go-skip_prune">skip_prune</a>, <a href="#oapi_codegen_go-kwargs">kwargs</a>)
 </pre>
 
 Generates Go bindings for an OpenAPI 3.0 spec.
@@ -26,6 +26,7 @@ typed API stub interface to implement your API against.
 | <a id="oapi_codegen_go-spec"></a>spec |  The OpenAPI 3.0 YAML specification for your API, must be self-contained.   |  none |
 | <a id="oapi_codegen_go-importpath"></a>importpath |  The importpath of the directory the rule is defined in, like 'github.com/&lt;org&gt;/&lt;repo&gt;/path/to/dir/api'. This is the import path of the generated Go library   |  none |
 | <a id="oapi_codegen_go-visibility"></a>visibility |  The visibility of the generated go_library target.   |  none |
+| <a id="oapi_codegen_go-skip_prune"></a>skip_prune |  Whether or not to generate code for unreferenced schema components.   |  <code>False</code> |
 | <a id="oapi_codegen_go-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -20,6 +20,7 @@ oapi_codegen_go(
     name = "api",
     importpath = "github.com/Silicon-Ally/rules_oapi_codegen/example/api",
     spec = "petstore.yaml",
+    skip_prune = True,
     visibility = ["//visibility:public"],
 )
 

--- a/example/main.go
+++ b/example/main.go
@@ -15,6 +15,9 @@ import (
 	oapimiddleware "github.com/deepmap/oapi-codegen/pkg/chi-middleware"
 )
 
+// This code shouldn't error because we've enabled skip-prune
+var _ api.UnreferencedComponent
+
 func main() {
 	if err := run(os.Args); err != nil {
 		log.Fatal(err)

--- a/example/petstore.yaml
+++ b/example/petstore.yaml
@@ -162,3 +162,12 @@ components:
         message:
           type: string
           description: Error message
+
+    UnreferencedComponent:
+      description: Exists to test the 'skip-prune' option
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Error message


### PR DESCRIPTION
This PR adds support for [the `skip-prune` option](https://github.com/deepmap/oapi-codegen/blob/af55078a5e93787f522e8d26dd550ebf28d4deb1/pkg/codegen/configuration.go#L92) of `oapi-codegen`, which generates structs for components that aren't otherwise referenced in the schema.

Signed-off-by: Brandon Sprague <brandon@sprague.mx>
